### PR TITLE
Add privacy policy for Chrome Web Store submission

### DIFF
--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Privacy Policy - Corezoid Deploy Shortcut</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            line-height: 1.6;
+            color: #333;
+        }
+        h1 {
+            color: #2c3e50;
+            border-bottom: 2px solid #3498db;
+            padding-bottom: 10px;
+        }
+        h2 {
+            color: #34495e;
+            margin-top: 30px;
+        }
+        .last-updated {
+            color: #7f8c8d;
+            font-style: italic;
+        }
+    </style>
+</head>
+<body>
+    <h1>Privacy Policy</h1>
+    <p class="last-updated">Last updated: June 10, 2025</p>
+    
+    <h2>Corezoid Deploy Shortcut Extension</h2>
+    <p>This privacy policy describes how the Corezoid Deploy Shortcut browser extension handles user information.</p>
+    
+    <h2>Information We Collect</h2>
+    <p>The extension collects and stores only the following information:</p>
+    <ul>
+        <li><strong>Domain Settings:</strong> The list of Corezoid domains you configure in the extension options (e.g., https://admin.corezoid.com)</li>
+    </ul>
+    
+    <h2>How We Use Information</h2>
+    <p>The domain settings are used solely to:</p>
+    <ul>
+        <li>Determine which websites the extension should activate on</li>
+        <li>Provide keyboard shortcut functionality (Ctrl+S/Cmd+S) for deploying processes in Corezoid</li>
+    </ul>
+    
+    <h2>Information Storage</h2>
+    <p>All information is stored locally in your browser using Chrome's storage API. The extension:</p>
+    <ul>
+        <li><strong>Does NOT</strong> transmit any data to external servers</li>
+        <li><strong>Does NOT</strong> collect personal information</li>
+        <li><strong>Does NOT</strong> track user behavior</li>
+        <li><strong>Does NOT</strong> share data with third parties</li>
+    </ul>
+    
+    <h2>Permissions Explanation</h2>
+    <p>The extension requests the following permissions:</p>
+    <ul>
+        <li><strong>Storage:</strong> To save your domain configuration settings</li>
+        <li><strong>ActiveTab:</strong> To access the current page and provide keyboard shortcuts on Corezoid process editor pages</li>
+        <li><strong>Host Permissions:</strong> To work with various Corezoid installations on different domains</li>
+    </ul>
+    
+    <h2>Data Security</h2>
+    <p>Your domain settings are stored securely in your browser's local storage and are never transmitted over the internet.</p>
+    
+    <h2>Changes to This Policy</h2>
+    <p>We may update this privacy policy from time to time. Any changes will be reflected in the "Last updated" date above.</p>
+    
+    <h2>Contact</h2>
+    <p>If you have questions about this privacy policy, please contact: yevhen.porechnyi@corezoid.com</p>
+</body>
+</html>


### PR DESCRIPTION
# Add privacy policy for Chrome Web Store submission

This PR adds a simple privacy-policy.html file required for Chrome Web Store submission.

## Changes Made

- **Added privacy-policy.html** - Simple, clean privacy policy explaining:
  - Extension only stores domain configuration settings locally
  - No personal data collection or transmission
  - No third-party data sharing
  - Clear explanation of required permissions (storage, activeTab, host permissions)

## Purpose

Required for Chrome Web Store submission to explain:
- Storage justification: Domain settings persistence
- ActiveTab justification: Keyboard shortcuts and Deploy button interaction
- Host permission justification: Support for various Corezoid installations

## Content

- Professional styling with clean layout
- Clear sections explaining data handling
- Contact information included
- Last updated date for maintenance

Link to Devin run: https://app.devin.ai/sessions/8550659ad5814cf6a9fe21e2865c11e7
Requested by: yevhen.porechnyi@corezoid.com
