### PR TITLE
Fix modal context clearing and bump version to 1.1.3

### DIFF
--- a/injected.js
+++ b/injected.js
@@ -18,17 +18,8 @@ function initBackbonePatch() {
         active_popup_view_context.model = this.model;
       }
       this.on('destroy', () => {
-        console.log('Corezoid Deploy Shortcut: View destroy event fired', {
-          isPopup: this.options?.isPopup,
-          hasCallback: !!this.options?.popupCloseCallback,
-          currentContextModel: active_popup_view_context.model,
-          thisModel: this.model,
-          contextWillBeCleared: active_popup_view_context.model === this.model
-        });
-        
         active_popup_view_context.callback = null;
         active_popup_view_context.model = null;
-        
         console.log('Corezoid Deploy Shortcut: Active popup context cleared');
       });
     }

--- a/injected.js
+++ b/injected.js
@@ -9,7 +9,7 @@ function initBackbonePatch() {
     }
 
     const { View: OrigView } = window.Backbone;
-    
+
     function PatchedView(options, ...args) {
       OrigView.call(this, options, ...args);
       const { isPopup, popupCloseCallback: cb } = this.options;
@@ -17,6 +17,20 @@ function initBackbonePatch() {
         active_popup_view_context.callback = cb;
         active_popup_view_context.model = this.model;
       }
+      this.on('destroy', () => {
+        console.log('Corezoid Deploy Shortcut: View destroy event fired', {
+          isPopup: this.options?.isPopup,
+          hasCallback: !!this.options?.popupCloseCallback,
+          currentContextModel: active_popup_view_context.model,
+          thisModel: this.model,
+          contextWillBeCleared: active_popup_view_context.model === this.model
+        });
+        
+        active_popup_view_context.callback = null;
+        active_popup_view_context.model = null;
+        
+        console.log('Corezoid Deploy Shortcut: Active popup context cleared');
+      });
     }
 
     PatchedView.prototype = Object.create(OrigView.prototype);
@@ -33,7 +47,7 @@ function initBackbonePatch() {
   }
 
   console.log('Corezoid Deploy Shortcut: Backbone not ready, setting up retry mechanism');
-  
+
   const observer = new MutationObserver(() => {
     if (tryInitialize()) {
       observer.disconnect();

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Corezoid Deploy Shortcut",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Adds Ctrl+S keyboard shortcut for Deploy action in Corezoid process editor",
   "browser_specific_settings": {
     "gecko": {


### PR DESCRIPTION
# Fix modal context clearing and bump version to 1.1.3

This PR implements a solution to clear `active_popup_view_context` when modal windows close, preventing unintended synchronization when Ctrl+S is pressed outside of modal windows.

## Changes Made

### 1. Modal Context Clearing (injected.js)
- **Added destroy event handler** to `PatchedView` constructor
- **Clears `active_popup_view_context`** when Backbone views are destroyed
- **Simple logging** for debugging modal closure events
- **Prevents synchronization** when modal is not actually open

### 2. Version Update (manifest.json)
- **Bumped version** from 1.1.2 to 1.1.3
- **Reflects modal context improvements** in version number

## Technical Implementation

```javascript
this.on('destroy', () => {
  active_popup_view_context.callback = null;
  active_popup_view_context.model = null;
  console.log('Corezoid Deploy Shortcut: Active popup context cleared');
});
```

## Problem Solved

- **Issue**: `active_popup_view_context` was never cleared when modal windows closed
- **Result**: Ctrl+S would trigger synchronization even when modal was not visible
- **Solution**: Backbone view `destroy` event automatically clears context when modal closes

## Benefits

- ✅ **Prevents unintended synchronization** when modal is closed
- ✅ **Uses standard Backbone lifecycle events** for reliable cleanup
- ✅ **Simple and maintainable** implementation
- ✅ **Backward compatible** with existing functionality

## Testing

- Modal context is properly cleared when modal windows close
- Synchronization only occurs when modal is actually open
- Ctrl+S behavior unchanged when modal is visible
- No impact on existing keyboard shortcut functionality

Link to Devin run: https://app.devin.ai/sessions/8550659ad5814cf6a9fe21e2865c11e7
Requested by: yevhen.porechnyi@corezoid.com