### PR TITLE
Fix Backbone patch issues: destroy handler scope and timeout clearing

### DIFF
--- a/injected.js
+++ b/injected.js
@@ -16,12 +16,12 @@ function initBackbonePatch() {
       if (isPopup && typeof cb === 'function') {
         active_popup_view_context.callback = cb;
         active_popup_view_context.model = this.model;
+        this.on('destroy', () => {
+          active_popup_view_context.callback = null;
+          active_popup_view_context.model = null;
+          console.log('Corezoid Deploy Shortcut: Active popup context cleared');
+        });
       }
-      this.on('destroy', () => {
-        active_popup_view_context.callback = null;
-        active_popup_view_context.model = null;
-        console.log('Corezoid Deploy Shortcut: Active popup context cleared');
-      });
     }
 
     PatchedView.prototype = Object.create(OrigView.prototype);
@@ -42,13 +42,14 @@ function initBackbonePatch() {
   const observer = new MutationObserver(() => {
     if (tryInitialize()) {
       observer.disconnect();
+      clearTimeout(timeoutId);
       console.log('Corezoid Deploy Shortcut: Backbone patched successfully via retry mechanism');
     }
   });
 
   observer.observe(document, { childList: true, subtree: true });
 
-  setTimeout(() => {
+  const timeoutId = setTimeout(() => {
     observer.disconnect();
     console.log('Corezoid Deploy Shortcut: Backbone patch initialization timed out after 10 seconds');
   }, 10000);


### PR DESCRIPTION
# Fix Backbone patch issues: destroy handler scope and timeout clearing  This PR addresses two critical issues in the Backbone patch initialization mechanism in `injected.js`:  ## Issues Fixed  ### 1. Destroy Event Handler Scope Issue **Problem:** The `destroy` event handler was being attached to ALL Backbone views, not just popup views **Solution:** Moved the `this.on('destroy', ...)` handler inside the `if (isPopup && typeof cb === 'function')` condition  **Before:** ```javascript function PatchedView(options, ...args) {   // ... popup context setup   this.on('destroy', () => {     // This ran for ALL views, not just popups   }); } ```  **After:** ```javascript function PatchedView(options, ...args) {   if (isPopup && typeof cb === 'function') {     // ... popup context setup     this.on('destroy', () => {       // Now only runs for popup views     });   } } ```  ### 2. Timeout Not Cleared on Successful Retry **Problem:** When Backbone initialization succeeded via MutationObserver, the 10-second timeout was never cleared, causing false timeout messages **Solution:** Store `timeoutId` and call `clearTimeout()` when initialization succeeds through retry mechanism  **Before:** ```javascript const observer = new MutationObserver(() => {   if (tryInitialize()) {     observer.disconnect();     // Missing: clearTimeout(timeoutId)   } });  setTimeout(() => {   // This always fired after 10 seconds, even on success }, 10000); ```  **After:** ```javascript const observer = new MutationObserver(() => {   if (tryInitialize()) {     observer.disconnect();     clearTimeout(timeoutId); // ✅ Now properly cleared   } });  const timeoutId = setTimeout(() => {   // Only fires if initialization actually times out }, 10000); ```  ## Impact  - ✅ **Destroy handlers only execute for popup views** - prevents unnecessary context clearing for non-modal views - ✅ **Eliminates false timeout messages** - timeout only logs when initialization actually fails - ✅ **Cleaner console output** - no more "timed out" messages after successful retry initialization - ✅ **More efficient** - fewer event handlers attached to non-popup views  ## Testing  - Verified destroy event handler only attaches to popup views with valid callbacks - Confirmed timeout is properly cleared when MutationObserver succeeds - No timeout messages appear when Backbone loads asynchronously but successfully - Modal context clearing still works correctly for actual popup views  Link to Devin run: https://app.devin.ai/sessions/8550659ad5814cf6a9fe21e2865c11e7 Requested by: yevhen.porechnyi@corezoid.com 